### PR TITLE
Fix framework name `lit-element` to `lit`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const frameworks = Object.entries({
   vue: "green",
   react: "cyan",
   preact: "magenta",
-  "lit-element": "blue",
+  lit: "blue",
   svelte: "red",
 }).map(([name, color]) => ({
   name: chalk[color](name),


### PR DESCRIPTION
Hi, I created a project via `yarn create vite-pwa fragmemo-pwa --ts`

```sh
 ❯ yarn create vite-pwa fragmemo-pwa --ts
 yarn create v1.22.11
 [1/4] 🔍  Resolving packages...
 [2/4] 🚚  Fetching packages...
 [3/4] 🔗  Linking dependencies...
 warning "create-vite-pwa > jscodeshift@0.13.0" has unmet peer dependency "@babel/preset-env@^7.1.6".
 [4/4] 🔨  Building fresh packages...

 success Installed "create-vite-pwa@0.1.0" with binaries:
    	- create-vite-pwa
    	- cvpwa
? Select a framework: lit-element

Scaffolding lit-element project with TypeScript in:
/Users/noriyo_tcp/MyPlayground/fragmemo-pwa
ENOENT: no such file or directory, lstat '/Users/noriyo_tcp/.config/yarn/global/node_modules/create-vite/template-lit-element-ts'
```

The project directory was created but it was empty!


`lit-element` was renamed to `lit` at https://github.com/vitejs/vite/pull/5012

I fixed it and it seems to work fine 😄

![スクリーンショット 2021-10-23 4 39 05](https://user-images.githubusercontent.com/5820754/138514981-b748e639-8e68-424d-bdb4-ddbdcbf9f77e.png)


```sh
 ❯ node create-vite-pwa/index.js create-vite-pwa-fixed --ts
? Select a framework: lit

Scaffolding lit project with TypeScript in:
/Users/noriyo_tcp/MyPlayground/create-vite-pwa-fixed

Done. Now run:

	cd create-vite-pwa-fixed
	npm install
	npm run dev
```
